### PR TITLE
Add Contributor Covenant Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as contributors and maintainers pledge to make participation in this project and our community a harassment-free experience for everyone.
+
+We are committed to creating an open, welcoming, and inclusive environment. All contributors — regardless of age, gender identity, level of experience, nationality, disability, or background — should feel safe and respected.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of different opinions and experiences
+- Accepting constructive feedback graciously
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+- Harassment, insults, or derogatory comments
+- Discriminatory jokes or language
+- Sharing others’ private information without permission
+- Any behavior that would reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying and enforcing this Code of Conduct. They have the right and responsibility to remove or reject contributions that violate this policy.
+
+## Reporting
+If you witness or experience unacceptable behavior, please report it using the project’s issue tracker or contact the maintainers.
+
+- Backend Issues: https://github.com/OSS-Group11/jjigit-be/issues  
+- Frontend Issues: https://github.com/OSS-Group11/jjigit-fe/issues  
+- AI Issues: https://github.com/OSS-Group11/jjigit-ai/issues  
+
+All reports will be reviewed and handled promptly and confidentially.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
This document outlines the Code of Conduct for contributors and maintainers, promoting a harassment-free and inclusive environment.